### PR TITLE
Remove local forest-fire-spread dependency

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -8,7 +8,6 @@
       "name": "forest-fire-spread",
       "version": "0.0.0",
       "dependencies": {
-        "forest-fire-spread": "file:",
         "sass-embedded": "^1.86.3",
         "vue": "^3.5.13"
       },
@@ -1095,10 +1094,6 @@
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "license": "MIT"
-    },
-    "node_modules/forest-fire-spread": {
-      "resolved": "",
-      "link": true
     },
     "node_modules/fsevents": {
       "version": "2.3.3",

--- a/front/package.json
+++ b/front/package.json
@@ -9,7 +9,6 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "forest-fire-spread": "file:",
     "sass-embedded": "^1.86.3",
     "vue": "^3.5.13"
   },


### PR DESCRIPTION
## Summary
- remove the local `forest-fire-spread` dependency from `front/package.json`
- update `front/package-lock.json` accordingly

## Testing
- `npm install` *(fails: unable to reach npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_684ae00a03388320956134f343929541